### PR TITLE
🔧 update (ci): bump release-build-flow-action to v1.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create Release
-        uses: wgtechlabs/release-build-flow-action@5c5896446fd0631b74a3c94d589ad733a94dbfae # v1.4.3
+        uses: wgtechlabs/release-build-flow-action@v1.5.0 # v1.5.0
         with:
           github-token: ${{ secrets.GH_PAT }}
           monorepo: 'true'


### PR DESCRIPTION
This pull request updates the release workflow to use a newer version of the `wgtechlabs/release-build-flow-action` GitHub Action. This ensures that the release process benefits from the latest features and bug fixes.

Release workflow update:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L23-R23): Upgraded the `wgtechlabs/release-build-flow-action` from version `v1.4.3` to `v1.5.0` for the "Create Release" step.