### PR TITLE
🔧 update (cli): add --docker flag for container environments

### DIFF
--- a/src/cli/src/commands/setup.ts
+++ b/src/cli/src/commands/setup.ts
@@ -235,6 +235,7 @@ export async function setupCommand(): Promise<void> {
 
     if (p.isCancel(continueAnyway) || !continueAnyway) {
       p.outro(theme.dim('Setup cancelled. Use --docker or --web flag for container environments.'));
+      await cleanup(secretsManager, configManager);
       process.exit(0);
     }
   }

--- a/src/cli/src/commands/setup.ts
+++ b/src/cli/src/commands/setup.ts
@@ -51,6 +51,7 @@ import { buildProviderKeyName, SecretsManager } from '@tinyclaw/secrets';
 import type { StreamCallback } from '@tinyclaw/types';
 import { createWebUI } from '@tinyclaw/web';
 import QRCode from 'qrcode';
+import { isRunningInContainer } from '../detect-container.js';
 import { showBanner } from '../ui/banner.js';
 import { theme } from '../ui/theme.js';
 
@@ -209,6 +210,34 @@ export async function setupCommand(): Promise<void> {
   const configManager = await ConfigManager.create();
 
   p.intro(theme.brand("Let's set up Tiny Claw"));
+
+  // --- Container environment warning ----------------------------------
+
+  if (isRunningInContainer()) {
+    p.note(
+      theme.warn('Container Environment Detected') +
+        '\n\n' +
+        'Interactive CLI setup may not work properly in Docker/containers.\n' +
+        'If prompts freeze or fail, cancel and run:\n\n' +
+        '  ' +
+        theme.cmd('tinyclaw setup --docker') +
+        '\n\n' +
+        'Or use ' +
+        theme.cmd('--web') +
+        ' for browser-based setup.',
+      'Docker/Container',
+    );
+
+    const continueAnyway = await p.confirm({
+      message: 'Continue with interactive setup anyway?',
+      initialValue: false,
+    });
+
+    if (p.isCancel(continueAnyway) || !continueAnyway) {
+      p.outro(theme.dim('Setup cancelled. Use --docker or --web flag for container environments.'));
+      process.exit(0);
+    }
+  }
 
   // --- Security warning -----------------------------------------------
 

--- a/src/cli/src/detect-container.ts
+++ b/src/cli/src/detect-container.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { logger } from '@tinyclaw/logger';
 
 /**
  * Detect if running inside a Docker container or CI environment.
@@ -12,16 +13,16 @@ export function isRunningInContainer(): boolean {
     if (existsSync('/.dockerenv')) {
       return true;
     }
-  } catch {
-    /* ignore */
+  } catch (err) {
+    logger.debug('Container detection: failed to check /.dockerenv', err);
   }
   try {
     const cgroup = readFileSync('/proc/1/cgroup', 'utf8');
     if (/docker|containerd|kubepods|lxc|podman/i.test(cgroup)) {
       return true;
     }
-  } catch {
-    /* ignore */
+  } catch (err) {
+    logger.debug('Container detection: failed to read /proc/1/cgroup', err);
   }
   return false;
 }

--- a/src/cli/src/detect-container.ts
+++ b/src/cli/src/detect-container.ts
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+/**
+ * Detect if running inside a Docker container or CI environment.
+ * Checks for common indicators: .dockerenv, cgroup, CI env vars, container-specific env vars.
+ */
+export function isRunningInContainer(): boolean {
+  if (process.env.CI || process.env.CONTAINER || process.env.DOCKER_CONTAINER) {
+    return true;
+  }
+  try {
+    if (existsSync('/.dockerenv')) {
+      return true;
+    }
+  } catch {
+    /* ignore */
+  }
+  try {
+    const cgroup = readFileSync('/proc/1/cgroup', 'utf8');
+    if (/docker|containerd|kubepods|lxc|podman/i.test(cgroup)) {
+      return true;
+    }
+  } catch {
+    /* ignore */
+  }
+  return false;
+}

--- a/src/cli/src/index.ts
+++ b/src/cli/src/index.ts
@@ -6,16 +6,18 @@
  * Lightweight argument router. No framework — just process.argv.
  *
  * Usage:
- *   tinyclaw              Show banner + help
- *   tinyclaw setup        Interactive first-time setup wizard
- *   tinyclaw setup --web  Start web onboarding at /setup
- *   tinyclaw start        Boot the agent (requires setup first)
- *   tinyclaw purge        Wipe all data for a fresh install
- *   tinyclaw --version    Print version
- *   tinyclaw --help       Show help
+ *   tinyclaw                 Show banner + help
+ *   tinyclaw setup           Interactive first-time setup wizard
+ *   tinyclaw setup --web     Start web onboarding at /setup
+ *   tinyclaw setup --docker  Force web mode for Docker/container environments
+ *   tinyclaw start           Boot the agent (requires setup first)
+ *   tinyclaw purge           Wipe all data for a fresh install
+ *   tinyclaw --version       Print version
+ *   tinyclaw --help          Show help
  */
 
 import { logger } from '@tinyclaw/logger';
+import { isRunningInContainer } from './detect-container.js';
 import { getVersion, showBanner } from './ui/banner.js';
 import { theme } from './ui/theme.js';
 
@@ -27,8 +29,10 @@ function showHelp(): void {
   console.log(`    ${theme.cmd('tinyclaw')} ${theme.dim('<command>')}`);
   console.log();
   console.log(`  ${theme.label('Commands')}`);
+  console.log(`    ${theme.cmd('setup')}    Interactive setup wizard`);
+  console.log(`             ${theme.dim('Use --web for browser onboarding')}`);
   console.log(
-    `    ${theme.cmd('setup')}    Interactive setup wizard (use --web for browser onboarding)`,
+    `             ${theme.dim('Use --docker for Docker/container environments (auto-detected)')}`,
   );
   console.log(`    ${theme.cmd('start')}    Start the Tiny Claw agent`);
   console.log(`    ${theme.cmd('config')}   Manage models, providers, and settings`);
@@ -40,6 +44,10 @@ function showHelp(): void {
   );
   console.log();
   console.log(`  ${theme.label('Options')}`);
+  console.log(
+    `    ${theme.dim('--docker')}        Force web-based setup for Docker/container environments`,
+  );
+  console.log(`    ${theme.dim('--web')}           Use web-based setup instead of CLI wizard`);
   console.log(`    ${theme.dim('--verbose')}       Show debug-level logs during start`);
   console.log(`    ${theme.dim('--version, -v')}   Show version number`);
   console.log(`    ${theme.dim('--help, -h')}      Show this help message`);
@@ -54,7 +62,11 @@ async function main(): Promise<void> {
 
   switch (command) {
     case 'setup': {
-      if (args.includes('--web')) {
+      // Detect Docker/container environment and auto-route to web mode
+      const isDocker = args.includes('--docker') || isRunningInContainer();
+      const isWeb = args.includes('--web') || isDocker;
+
+      if (isWeb) {
         // Web setup goes through supervisor so the restart mechanism works
         const { supervisedStart } = await import('./supervisor.js');
         await supervisedStart();

--- a/src/cli/tests/detect-container.test.ts
+++ b/src/cli/tests/detect-container.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for container environment detection (detect-container.ts).
+ *
+ * Uses module mocking to simulate Docker, CI, and non-container environments.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Store original env so we can restore after each test
+const originalEnv = { ...process.env };
+
+// Mock node:fs so we can control existsSync and readFileSync
+const mockExistsSync = mock(() => false);
+const mockReadFileSync = mock(() => '');
+
+mock.module('node:fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+}));
+
+// Mock logger to avoid side effects
+mock.module('@tinyclaw/logger', () => ({
+  logger: {
+    debug: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+  },
+}));
+
+// Import after mocks are set up
+const { isRunningInContainer } = await import('../src/detect-container.js');
+
+beforeEach(() => {
+  // Reset env vars
+  delete process.env.CI;
+  delete process.env.CONTAINER;
+  delete process.env.DOCKER_CONTAINER;
+
+  // Reset mocks
+  mockExistsSync.mockReset();
+  mockExistsSync.mockReturnValue(false);
+  mockReadFileSync.mockReset();
+  mockReadFileSync.mockReturnValue('');
+});
+
+afterEach(() => {
+  // Restore original environment
+  process.env = { ...originalEnv };
+});
+
+// -----------------------------------------------------------------------
+// Environment variable detection
+// -----------------------------------------------------------------------
+
+describe('environment variable detection', () => {
+  test('detects CI environment', () => {
+    process.env.CI = 'true';
+    expect(isRunningInContainer()).toBe(true);
+  });
+
+  test('detects CONTAINER environment', () => {
+    process.env.CONTAINER = 'true';
+    expect(isRunningInContainer()).toBe(true);
+  });
+
+  test('detects DOCKER_CONTAINER environment', () => {
+    process.env.DOCKER_CONTAINER = '1';
+    expect(isRunningInContainer()).toBe(true);
+  });
+});
+
+// -----------------------------------------------------------------------
+// .dockerenv file detection
+// -----------------------------------------------------------------------
+
+describe('.dockerenv detection', () => {
+  test('detects /.dockerenv file', () => {
+    mockExistsSync.mockReturnValue(true);
+    expect(isRunningInContainer()).toBe(true);
+  });
+
+  test('handles /.dockerenv check failure gracefully', () => {
+    mockExistsSync.mockImplementation(() => {
+      throw new Error('Permission denied');
+    });
+    // Should not throw, should fall through to next check
+    expect(isRunningInContainer()).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// cgroup detection
+// -----------------------------------------------------------------------
+
+describe('cgroup detection', () => {
+  test('detects docker in cgroup', () => {
+    mockReadFileSync.mockReturnValue('12:memory:/docker/abc123\n');
+    expect(isRunningInContainer()).toBe(true);
+  });
+
+  test('detects containerd in cgroup', () => {
+    mockReadFileSync.mockReturnValue('1:name=systemd:/containerd/abc\n');
+    expect(isRunningInContainer()).toBe(true);
+  });
+
+  test('detects kubepods in cgroup', () => {
+    mockReadFileSync.mockReturnValue('11:cpuset:/kubepods/pod-xyz\n');
+    expect(isRunningInContainer()).toBe(true);
+  });
+
+  test('detects lxc in cgroup', () => {
+    mockReadFileSync.mockReturnValue('10:devices:/lxc/container1\n');
+    expect(isRunningInContainer()).toBe(true);
+  });
+
+  test('detects podman in cgroup', () => {
+    mockReadFileSync.mockReturnValue('1:name=systemd:/podman/ctr-abc\n');
+    expect(isRunningInContainer()).toBe(true);
+  });
+
+  test('handles cgroup read failure gracefully', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT: no such file or directory');
+    });
+    expect(isRunningInContainer()).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Non-container environment
+// -----------------------------------------------------------------------
+
+describe('non-container environment', () => {
+  test('returns false when no container indicators found', () => {
+    mockReadFileSync.mockReturnValue('1:name=systemd:/init.scope\n');
+    expect(isRunningInContainer()).toBe(false);
+  });
+
+  test('returns false with empty cgroup', () => {
+    mockReadFileSync.mockReturnValue('');
+    expect(isRunningInContainer()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--docker` flag that routes to web-based setup (same as `--web`)
- Auto-detect Docker/container environments via `CI`, `CONTAINER`, `DOCKER_CONTAINER` env vars, `/.dockerenv` file, and `/proc/1/cgroup` container indicators
- Show container detection warning in interactive setup to guide users
- Extract shared `isRunningInContainer()` into `detect-container.ts`
- Updated help text with `--docker` documentation

## Testing

- [x] `isRunningInContainer()` returns `false` on local macOS
- [x] `isRunningInContainer()` returns `true` with `CI=true`
- [x] `isRunningInContainer()` returns `true` with `CONTAINER=1`
- [x] `isRunningInContainer()` returns `true` with `DOCKER_CONTAINER=1`
- [x] `--docker` flag routes to web/supervisor mode
- [x] `--web` flag still works
- [x] No flags = interactive mode
- [x] Help text shows `--docker` documentation
- [x] All existing CLI tests pass (0 regressions)
- [x] Biome lint passes (0 errors)
- [x] CLI build passes
- [ ] Run `tinyclaw setup --docker` in a container environment
- [ ] Verify auto-detection works by running in Docker without flags

## Related Issue

Closes #12

> **Note:** Supersedes #40 which was auto-closed after rebase force-push.

## Checklist

- [x] Code builds successfully (bun build)
- [x] Tests pass (bun test)
- [x] Documentation updated (help text)
- [x] Follows Clean Commit convention
- [x] CLA signed