### PR TITLE
🔧 update: improve shield SQL detection and CLI channel routing

### DIFF
--- a/packages/shield/src/matcher.ts
+++ b/packages/shield/src/matcher.ts
@@ -142,7 +142,23 @@ function evaluateCondition(
 
     // "tool.call with arguments containing SQL syntax (DROP, DELETE, UNION, --)"
     if (lc.includes('arguments containing')) {
-      const argsStr = JSON.stringify(event.toolArgs ?? {}).toLowerCase();
+      // Only scan fields that could be SQL injection vectors.
+      // Exclude content-body fields (document payloads written to files,
+      // not SQL parameters) to prevent false positives.
+      const CONTENT_FIELDS: ReadonlySet<string> = new Set([
+        'content',
+        'body',
+        'message',
+        'text',
+      ]);
+      const rawArgs = event.toolArgs ?? {};
+      const filteredArgs: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(rawArgs)) {
+        if (!CONTENT_FIELDS.has(key)) {
+          filteredArgs[key] = val;
+        }
+      }
+      const argsStr = JSON.stringify(filteredArgs).toLowerCase();
       // Extract keywords from parenthetical list
       const openIdx = condition.indexOf('(');
       const closeIdx = openIdx >= 0 ? condition.indexOf(')', openIdx + 1) : -1;
@@ -152,7 +168,13 @@ function evaluateCondition(
           .split(',')
           .map((k) => k.trim().toLowerCase());
         for (const keyword of keywords) {
-          if (keyword && argsStr.includes(keyword)) {
+          if (!keyword) continue;
+          if (keyword === '--') {
+            // Match SQL comment marker (--) but NOT markdown separators (---)
+            if (/(?<!-)--(?!-)/.test(argsStr)) {
+              return { matchedOn: 'tool.args', matchValue: keyword };
+            }
+          } else if (argsStr.includes(keyword)) {
             return { matchedOn: 'tool.args', matchValue: keyword };
           }
         }

--- a/packages/shield/src/matcher.ts
+++ b/packages/shield/src/matcher.ts
@@ -42,6 +42,17 @@ export interface MatchResult {
 }
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Tool argument keys that carry document payloads (not SQL parameters).
+ * Excluded from SQL injection scanning to prevent false positives on
+ * document writes (e.g. write_file with `content`, chat with `message`).
+ */
+const CONTENT_FIELDS: ReadonlySet<string> = new Set(['content', 'body', 'message', 'text']);
+
+// ---------------------------------------------------------------------------
 // Directive parsing
 // ---------------------------------------------------------------------------
 
@@ -145,12 +156,6 @@ function evaluateCondition(
       // Only scan fields that could be SQL injection vectors.
       // Exclude content-body fields (document payloads written to files,
       // not SQL parameters) to prevent false positives.
-      const CONTENT_FIELDS: ReadonlySet<string> = new Set([
-        'content',
-        'body',
-        'message',
-        'text',
-      ]);
       const rawArgs = event.toolArgs ?? {};
       const filteredArgs: Record<string, unknown> = {};
       for (const [key, val] of Object.entries(rawArgs)) {

--- a/packages/shield/tests/matcher.test.ts
+++ b/packages/shield/tests/matcher.test.ts
@@ -127,6 +127,61 @@ describe('matchEvent — tool.call', () => {
     expect(matches).toHaveLength(0);
   });
 
+  it('should not match -- in markdown separators (---) inside content fields', () => {
+    const threat = makeThreat({
+      recommendationAgent:
+        'BLOCK: tool.call with arguments containing SQL syntax (DROP, DELETE, UNION, --)',
+    });
+
+    const event: ShieldEvent = {
+      scope: 'tool.call',
+      toolName: 'heartware_write',
+      toolArgs: {
+        filename: 'FRIEND.md',
+        content: '# About My Owner\n\n- **Name:** Waren\n\n---\nThis file helps me understand you better.',
+      },
+    };
+
+    const matches = matchEvent(event, [threat]);
+    expect(matches).toHaveLength(0);
+  });
+
+  it('should not false-positive on content-body fields containing SQL words', () => {
+    const threat = makeThreat({
+      recommendationAgent:
+        'BLOCK: tool.call with arguments containing SQL syntax (DROP, DELETE, UNION, --)',
+    });
+
+    const event: ShieldEvent = {
+      scope: 'tool.call',
+      toolName: 'heartware_write',
+      toolArgs: {
+        filename: 'MEMORY.md',
+        content: 'User asked me to delete the old notes and drop the schedule',
+      },
+    };
+
+    const matches = matchEvent(event, [threat]);
+    expect(matches).toHaveLength(0);
+  });
+
+  it('should still block SQL keywords in non-content args', () => {
+    const threat = makeThreat({
+      recommendationAgent:
+        'BLOCK: tool.call with arguments containing SQL syntax (DROP, DELETE, UNION, --)',
+    });
+
+    const event: ShieldEvent = {
+      scope: 'tool.call',
+      toolName: 'db_query',
+      toolArgs: { query: 'DROP TABLE users; -- pwned' },
+    };
+
+    const matches = matchEvent(event, [threat]);
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches[0].matchedOn).toBe('tool.args');
+  });
+
   it('should match compatible scope/category', () => {
     const threat = makeThreat({
       category: 'prompt', // prompt category

--- a/packages/shield/tests/matcher.test.ts
+++ b/packages/shield/tests/matcher.test.ts
@@ -138,7 +138,8 @@ describe('matchEvent — tool.call', () => {
       toolName: 'heartware_write',
       toolArgs: {
         filename: 'FRIEND.md',
-        content: '# About My Owner\n\n- **Name:** Waren\n\n---\nThis file helps me understand you better.',
+        content:
+          '# About My Owner\n\n- **Name:** Waren\n\n---\nThis file helps me understand you better.',
       },
     };
 

--- a/src/cli/src/commands/start.ts
+++ b/src/cli/src/commands/start.ts
@@ -1376,7 +1376,18 @@ export async function startCommand(): Promise<void> {
   const gateway = createGateway();
 
   // Register web UI as a channel sender (SSE push)
-  gateway.register('web', webUI.getChannelSender());
+  const webSender = webUI.getChannelSender();
+  gateway.register('web', webSender);
+
+  // If the owner was claimed via CLI setup, the persisted ownerId has
+  // prefix "cli:" but only a "web" channel is registered. Register a
+  // "cli" alias so nudges for "cli:owner" route through the web sender.
+  if (persistedOwnerId?.startsWith('cli:') && !gateway.getRegisteredChannels().includes('cli')) {
+    gateway.register('cli', {
+      ...webSender,
+      name: `${webSender.name} (cli alias)`,
+    });
+  }
 
   // --- Nudge Engine -------------------------------------------------------
 

--- a/src/cli/tests/commands/start.test.ts
+++ b/src/cli/tests/commands/start.test.ts
@@ -272,9 +272,11 @@ const mockWebUIStop = mock(() => Promise.resolve());
 
 // ── Mock @tinyclaw/gateway ────────────────────────────────────────────
 
+const mockGatewayRegister = mock(() => {});
+
 mock.module('@tinyclaw/gateway', () => ({
   createGateway: mock(() => ({
-    register: mock(() => {}),
+    register: mockGatewayRegister,
     unregister: mock(() => {}),
     send: mock(() => Promise.resolve({ success: true, channel: 'web', userId: 'web:owner' })),
     broadcast: mock(() => Promise.resolve([])),
@@ -375,6 +377,7 @@ beforeEach(() => {
     readyTag: 'Tiny Claw#1234',
     lastError: null,
   }));
+  mockGatewayRegister.mockClear();
 });
 
 afterEach(() => {
@@ -393,6 +396,31 @@ describe('startCommand', () => {
   test('starts the web UI server', async () => {
     await startCommand();
     expect(mockWebUIStart).toHaveBeenCalled();
+  });
+
+  test('registers cli channel alias for cli-prefixed owner', async () => {
+    await startCommand();
+    const registeredChannels = mockGatewayRegister.mock.calls.map(
+      ([channel]: [string, ...unknown[]]) => channel,
+    );
+    expect(registeredChannels).toContain('cli');
+  });
+
+  test('does not register cli channel alias for non-cli-prefixed owner', async () => {
+    mockConfigGet.mockImplementation((key: string) => {
+      if (key === 'providers.starterBrain.model') return 'kimi-k2.5:cloud';
+      if (key === 'providers.starterBrain.baseUrl') return 'https://ollama.com';
+      if (key === 'heartware.seed') return 42;
+      if (key === 'owner.ownerId') return 'web:owner';
+      if (key === 'channels.discord.enabled') return true;
+      if (key === 'plugins.enabled') return ['@tinyclaw/plugin-channel-discord'];
+      return undefined;
+    });
+    await startCommand();
+    const registeredChannels = mockGatewayRegister.mock.calls.map(
+      ([channel]: [string, ...unknown[]]) => channel,
+    );
+    expect(registeredChannels).not.toContain('cli');
   });
 
   test('initializes heartware', async () => {


### PR DESCRIPTION
## Summary
Two reliability improvements: the shield package's SQL injection matcher was generating false positives by scanning content-body fields (e.g. `content`, `body`, `message`, `text`) that carry document payloads rather than SQL parameters, and the `--` markdown separator (`---`) was being misidentified as a SQL comment marker. Separately, the CLI now registers a channel alias to correctly handle CLI-prefixed owner routing.

## Changes
- **shield**: Exclude known content-body fields (`content`, `body`, `message`, `text`) from SQL injection argument scanning to prevent false positives on document writes
- **shield**: Tighten `--` detection with a negative-lookahead regex so markdown `---` separators are not treated as SQL comment markers
- **shield**: Add three new matcher tests — markdown separator false positive, content-field SQL word false positive, and a true-positive guard ensuring non-content args still block SQL keywords
- **cli**: Register a CLI channel alias to support CLI-prefixed owner routing

## Test Plan
- New unit tests in `packages/shield/tests/matcher.test.ts` cover all three scenarios:
  - `---` inside a `content` field → no match
  - SQL words (`delete`, `drop`) inside a `content` field → no match
  - `DROP TABLE … --` inside a non-content `query` field → match (true positive preserved)
- Run the shield test suite: `pnpm --filter shield test`
- Verify CLI alias routing manually or via existing CLI integration tests