### PR TITLE
📖 docs: add missing build step to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Everything above the plugin line is the **tiny core**. Channels, extra providers
 bun install
 ```
 
+### Build
+
+```bash
+bun run build
+```
+
 ### Run
 
 ```bash


### PR DESCRIPTION
## Summary

The README's Quick Start skips straight from `bun install` to `bun start`, but `bun start` resolves to `bun dist/index.js` (via `src/cli/package.json`) and `dist/` does not exist after a fresh install. A first-time follower of the docs hits:

```
$ bun start
$ bun run --cwd src/cli start
$ bun dist/index.js
error: Module not found "dist/index.js"
error: script "start" exited with code 1
```

This PR inserts a **Build** step between **Install** and **Run** so the documented flow actually works end to end.

## Reproduction

```bash
git clone … && cd tinyclaw
bun install
bun start        # <-- fails: Module not found "dist/index.js"
```

After the fix:

```bash
bun install
bun run build    # <-- added
bun start        # <-- CLI runs and prints usage
```

## Notes for reviewer

- Targeted `dev` per CONTRIBUTING.md.
- Minimal, docs-only change — no code touched.
- Separately, `bun start` alone prints CLI usage rather than opening `http://localhost:3000`; reaching the web UI seems to need `tinyclaw setup --web` / `tinyclaw start`. Happy to follow up in a second PR if you confirm the intended first-run flow.

## Checklist

- [x] PR targets `dev`
- [x] Commit follows Clean Commit (`📖 docs: …`)
- [x] Docs-only — no build/test impact